### PR TITLE
implement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.DS_Store
+npm-debug.log
+logs

--- a/README.md
+++ b/README.md
@@ -1,0 +1,42 @@
+# hive-perf
+
+Tiny performance tool for integrated testing.
+
+```
+npm i -g https://github.com/bitfinexcom/hive-perf
+```
+
+Prints stats for every X messages, format:
+
+```
+msg-name amount time diff
+
+EXECUTED 1000 1557830829647 376
+```
+
+## CLI usage
+
+Basic message match, matches all messages with `te_update_order_mem`:
+
+```
+hive-perf --match "te_update_order_mem" --amount 2
+```
+
+Match multiple messages (`te_update_order_mem` or `te_trade_mem`)
+
+```
+hive-perf --match "te_update_order_mem|te_trade_mem" --amount 2
+```
+
+Advanced usage, filtering. Matches all messages that contain `te_update_order_mem`
+**and** `EXECUTED`, **or** `foo_bar`:
+
+```
+hive-perf --match "te_update_order_mem:$:EXECUTED@|foo_bar" --amount=2
+```
+
+Pipe into CSV:
+
+```
+hive-perf --match "EXECUTED" --amount=2 --csv > results.csv
+```

--- a/bin/bin.js
+++ b/bin/bin.js
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+
+'use strict'
+
+const delimiter = ':$:'
+
+const argv = require('yargs')
+  .usage('Usage: $0 <match[:$:specifier]> [options]')
+  .option('match', {
+    describe: 'matching messages',
+    demand: true
+  })
+  .option('amount', {
+    describe: 'amount of messages to receive before logging',
+    demand: true
+  })
+  .option('queue', {
+    describe: 'pubsub message queue name',
+    default: 'bfx120:BFX2MWPUBc00'
+  })
+  .option('csv', {
+    describe: 'print csv output'
+  })
+  .argv
+
+const Perf = require('../')
+
+function logCsv (...args) {
+  console.log(args.join(';'))
+}
+
+const tmp = argv.match.split('|')
+const matches = tmp.map((el) => {
+  const res = el.split(delimiter)
+  if (!res[1]) res[1] = null
+  return res
+})
+
+const opts = {
+  log: argv.csv ? logCsv : console.log,
+  delimiter,
+  queue: argv.queue
+}
+
+const perf = new Perf(
+  matches,
+  argv.amount,
+  opts
+)
+
+perf.start()

--- a/index.js
+++ b/index.js
@@ -1,0 +1,108 @@
+'use strict'
+
+const EventEmitter = require('events')
+const Redis = require('ioredis')
+
+class Perf extends EventEmitter {
+  constructor (matches, amount, opts) {
+    super()
+
+    this.counter = {}
+    this.amount = amount
+
+    this.queue = opts.queue
+    this.qBuf = Buffer.from(opts.queue)
+    this.delimiter = opts.delimiter || ':$:'
+    this.log = opts.log
+
+    this.matches = this.createMatches(matches)
+  }
+
+  start (cb = () => {}) {
+    const redis = this.redis = new Redis()
+    redis.subscribe(this.queue, (err, _count) => {
+      if (err) return cb(err)
+
+      cb(null)
+    })
+
+    redis.on('messageBuffer', (ch, msg) => {
+      if (!ch.equals(this.qBuf)) {
+        return
+      }
+
+      this.count(msg)
+    })
+  }
+
+  count (msg) {
+    const m = this.matches
+    const amount = this.amount
+    const counter = this.counter
+
+    for (let i = 0; i < m.length; i++) {
+      if (!msg.includes(m[i][0])) {
+        continue
+      }
+
+      if (m[i][1] === null) {
+        counter[i][1] = counter[i][1] + 1
+
+        if (!counter[i][2]) {
+          counter[i][2] = Date.now()
+        }
+
+        if (counter[i][1] === amount) {
+          const now = Date.now()
+          const diff = now - counter[i][2]
+          counter[i][1] = 0
+          counter[i][2] = now
+
+          this.log(counter[i][0], amount, counter[i][2], diff)
+        }
+
+        break
+      }
+
+      if (!msg.includes(m[i][1])) {
+        continue
+      }
+
+      counter[i][1] = counter[i][1] + 1
+      if (!counter[i][2]) {
+        counter[i][2] = Date.now()
+      }
+
+      if (counter[i][1] === amount) {
+        const now = Date.now()
+        const diff = now - counter[i][2]
+        counter[i][1] = 0
+        counter[i][2] = now
+
+        this.log(counter[i][0], amount, counter[i][2], diff)
+      }
+    }
+  }
+
+  stop () {
+    this.redis.unsubscribe(this.queue)
+    this.redis.disconnect()
+  }
+
+  createMatches (matches) {
+    const res = matches.map((el) => {
+      const scnd = el[1] ? Buffer.from(el[1]) : null
+
+      return [ Buffer.from(el[0]), scnd ]
+    })
+
+    matches.forEach((el, i) => {
+      el = el[1] ? el.join(this.delimiter) : el[0]
+      this.counter[i] = [ el, 0, null ]
+    })
+
+    return res
+  }
+}
+
+module.exports = Perf

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "hive-perf",
+  "version": "1.0.0",
+  "description": "Hive performance tools",
+  "bin": "bin/bin.js",
+  "main": "index.js",
+  "scripts": {
+    "test": "standard && mocha"
+  },
+  "author": "Robert <robert@bitfinex.com>",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "ioredis": "^4.9.3",
+    "yargs": "^13.2.4"
+  },
+  "devDependencies": {
+    "mocha": "^6.1.4",
+    "standard": "^12.0.1"
+  }
+}

--- a/test-example.js
+++ b/test-example.js
@@ -1,0 +1,15 @@
+'use strict'
+
+const queue = 'bfx120:BFX2MWPUBc00'
+const Redis = require('ioredis')
+const redis = new Redis()
+
+redis.connect(() => {
+  redis.publish(queue, '"a":"te_update_order_mem",EXECUTED@10.00')
+  // redis.publish(queue, '"a":"te_update_order_mem",EXECUTED@10.00')
+  // redis.publish(queue, '"a":"te_update_order_mem",EXECUTED@10.00')
+
+  redis.publish(queue, '"a":"te_update_order_mem"')
+  redis.publish(queue, '"a":"te_update_order_mem"')
+  redis.publish(queue, '"a":"te_update_order_mem"')
+})

--- a/test/basic.js
+++ b/test/basic.js
@@ -1,0 +1,120 @@
+/* eslint-env mocha */
+
+'use strict'
+
+const Redis = require('ioredis')
+const assert = require('assert')
+const Perf = require('../')
+
+const queue = 'bfxtest'
+
+const log = console.log
+
+function start (perf, cb) {
+  const redis = new Redis()
+
+  redis.connect(() => {})
+  perf.start(cb)
+
+  return {
+    redis,
+    stop: function stop () {
+      redis.disconnect()
+      perf.stop()
+    }
+  }
+}
+
+const msg = JSON.stringify({
+  't': 1557767768.6732,
+  'seq': 1249389.504654,
+  'a': 'te_update_order_mem',
+  'o': {
+    'id': 7932567514,
+    'user_id': 1,
+    'pair': 'BTCUSD',
+    'v_pair': 'BTCUSD',
+    'mseq': 2,
+    'active': 0,
+    'status': 'EXECUTED @ 10.0(-15.0009)',
+    'amount': '0',
+    'amount_orig': '-15.0009',
+    'hidden': 0,
+    'type': 'EXCHANGE LIMIT',
+    'type_prev': null,
+    'routing': '',
+    'price': '10.0',
+    'price_avg': '10.0',
+    'swap_rate_max': '0.0075',
+    'gid': null,
+    'cid': 42618293841,
+    'cid_date': '2018-01-09',
+    'flags': 0,
+    'lcy_post_only': 0,
+    'placed_id': null,
+    'vir': 1,
+    'created_at': '2018-01-09T11:50:18.330Z',
+    'tif': null,
+    'liq_stage': null
+  }
+})
+
+describe('basic integration', () => {
+  it('counts by actions', (done) => {
+    const d1 = Date.now()
+
+    const matches = [['te_update_order_mem', null], ['te_custom_event', null]]
+    const perf = new Perf(matches, 3, { queue, log })
+
+    const { redis, stop } = start(perf, (err) => {
+      if (err) throw err
+      redis.publish(queue, 'Hello again!')
+
+      redis.publish(queue, msg)
+      redis.publish(queue, msg)
+
+      redis.publish(queue, '"a":"te_custom_event"')
+      redis.publish(queue, '"a":"te_custom_event"')
+      redis.publish(queue, '"a":"te_custom_event"')
+      redis.publish(queue, '"a":"te_custom_event"')
+    })
+
+    setTimeout(() => {
+      assert.strictEqual(perf.counter[0][1], 2)
+      assert.strictEqual(perf.counter[1][1], 1)
+
+      assert.ok(perf.counter[0][2] > d1)
+      assert.ok(perf.counter[1][2] > d1)
+
+      stop()
+
+      done()
+    }, 30)
+  })
+
+  it('supports deep matches', (done) => {
+    const d1 = Date.now()
+
+    const matches = [['te_update_order_mem', 'EXECUTED']]
+    const perf = new Perf(matches, 5, { queue, log })
+
+    const { redis, stop } = start(perf, (err) => {
+      if (err) throw err
+      redis.publish(queue, 'Hello again!')
+
+      redis.publish(queue, '"a":"te_update_order_mem",EXECUTED@10.00')
+      redis.publish(queue, '"a":"te_update_order_mem",EXECUTED@10.00')
+      redis.publish(queue, '"a":"te_update_order_mem",EXECUTED@10.00')
+
+      redis.publish(queue, '"a":"te_update_order_mem",EXECU@10.00')
+    })
+
+    setTimeout(() => {
+      assert.strictEqual(perf.counter[0][1], 3)
+      assert.ok(perf.counter[0][2] > d1)
+
+      stop()
+      done()
+    }, 30)
+  })
+})


### PR DESCRIPTION
implement a small tool to measure trade or any other trading-event throughput.

print csv with 

```
hive-perf --match "te_update_order_mem:$:EXECUTED" --amount=2000 --csv
```

then remove outliers with 90 percentile or something to take the average time.

Tested with a modified "hammer spec" that sends more trades.